### PR TITLE
Add function that returns password reset token for send reset email path

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -66,9 +66,7 @@
 
           ## Refactoring Opportunities
           {Credo.Check.Refactor.DoubleBooleanNegation, []},
-          {Credo.Check.Refactor.ImplicitTry, []},
           {Credo.Check.Refactor.IoPuts, []},
-          {Credo.Check.Refactor.MapInto, []},
           {Credo.Check.Refactor.MatchInCondition, []},
           {Credo.Check.Refactor.NegatedConditionsInUnless, []},
           {Credo.Check.Refactor.NegatedConditionsWithElse, []},
@@ -82,6 +80,7 @@
           {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
           {Credo.Check.Warning.IExPry, []},
           {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, [priority: :low]},
           {Credo.Check.Warning.OperationOnSameValues, []},
           {Credo.Check.Warning.OperationWithConstantResult, []},
           {Credo.Check.Warning.RaiseInsideRescue, []},
@@ -97,11 +96,7 @@
           {Credo.Check.Warning.UnusedTupleOperation, []}
         ],
         disabled: [
-          # Disable Logger metadata warnings for observability/structured logging
-          {Credo.Check.Warning.LoggerMetadata, []},
-
           # Disable some overly pedantic checks
-          {Credo.Check.Design.AliasUsage, []},
           {Credo.Check.Readability.Specs, []}
         ]
       }

--- a/lib/trade_machine/data/user.ex
+++ b/lib/trade_machine/data/user.ex
@@ -6,6 +6,7 @@ defmodule TradeMachine.Data.User do
   alias TradeMachine.Repo
   require Logger
   require Ecto.Query
+  import Ecto.Query
 
   @derive {Swoosh.Email.Recipient, name: :display_name, address: :email}
 
@@ -35,6 +36,24 @@ defmodule TradeMachine.Data.User do
 
   def get_by_id(id) when is_binary(id) do
     Repo.get(__MODULE__, id)
+  end
+
+  @spec get_by_id_with_password_reset_token(String.t()) :: __MODULE__.t() | nil
+  def get_by_id_with_password_reset_token(id) when is_binary(id) do
+    from(u in __MODULE__,
+      where: u.id == ^id,
+      select: %__MODULE__{
+        id: u.id,
+        display_name: u.display_name,
+        email: u.email,
+        status: u.status,
+        role: u.role,
+        password_reset_token: u.password_reset_token,
+        inserted_at: u.inserted_at,
+        updated_at: u.updated_at
+      }
+    )
+    |> Repo.one()
   end
 
   @spec get_user_by_csv_name(String.t()) :: __MODULE__.t() | nil

--- a/lib/trade_machine/mailer/email_view.ex
+++ b/lib/trade_machine/mailer/email_view.ex
@@ -3,11 +3,5 @@ defmodule TradeMachine.Mailer.EmailView do
     root: "lib/trade_machine/mailer/templates",
     namespace: TradeMachine.Mailer
 
-  # Import Phoenix.HTML functions for basic HTML helpers
-  import Phoenix.HTML
-  import Phoenix.HTML.Form
   use PhoenixHTMLHelpers
-
-  # Import any other helpers you might need
-  import TradeMachineWeb.Gettext
 end

--- a/lib/trade_machine/mailer/layout_view.ex
+++ b/lib/trade_machine/mailer/layout_view.ex
@@ -3,11 +3,5 @@ defmodule TradeMachine.Mailer.LayoutView do
     root: "lib/trade_machine/mailer/templates",
     namespace: TradeMachine.Mailer
 
-  # Import Phoenix.HTML functions for basic HTML helpers
-  import Phoenix.HTML
-  import Phoenix.HTML.Form
   use PhoenixHTMLHelpers
-
-  # Import any other helpers you might need
-  import TradeMachineWeb.Gettext
 end

--- a/lib/trade_machine/mailer/mailer.ex
+++ b/lib/trade_machine/mailer/mailer.ex
@@ -5,7 +5,7 @@ defmodule TradeMachine.Mailer do
   def send_password_reset_email(user_id) do
     Logger.info("Sending password reset email", user_id: user_id)
 
-    case TradeMachine.Data.User.get_by_id(user_id) do
+    case TradeMachine.Data.User.get_by_id_with_password_reset_token(user_id) do
       nil ->
         Logger.error("User not found for ID", user_id: user_id)
         {:error, :user_not_found}
@@ -15,10 +15,35 @@ defmodule TradeMachine.Mailer do
     end
   end
 
+  def send_registration_email(user_id) do
+    Logger.info("Sending registration email", user_id: user_id)
+
+    case TradeMachine.Data.User.get_by_id(user_id) do
+      nil ->
+        Logger.error("User not found for ID", user_id: user_id)
+        {:error, :user_not_found}
+
+      user ->
+        TradeMachine.Mailer.RegistrationEmail.send(user)
+    end
+  end
+
+  def send_test_email(user_id) do
+    Logger.info("Sending test email", user_id: user_id)
+
+    case TradeMachine.Data.User.get_by_id(user_id) do
+      nil ->
+        Logger.error("User not found for ID", user_id: user_id)
+        {:error, :user_not_found}
+
+      user ->
+        TradeMachine.Mailer.TestEmail.send(user)
+    end
+  end
+
   defmacro __using__(_opts) do
     quote do
       import Swoosh.Email
-      import TradeMachine.Mailer, only: [from_email: 0, from_tuple: 0]
 
       use Phoenix.Swoosh,
         view: TradeMachine.Mailer.EmailView,

--- a/lib/trade_machine/mailer/registration_email.ex
+++ b/lib/trade_machine/mailer/registration_email.ex
@@ -1,0 +1,30 @@
+defmodule TradeMachine.Mailer.RegistrationEmail do
+  use TradeMachine.Mailer
+
+  alias TradeMachine.Data.User
+
+  @spec send(User.t()) :: {:ok, any()} | {:error, any()}
+  def send(user = %User{}) do
+    generate_email(user)
+    |> do_deliver()
+  end
+
+  @spec send!(User.t()) :: Swoosh.Email.t()
+  def send!(user = %User{}) do
+    generate_email(user)
+    |> do_deliver!()
+  end
+
+  @spec generate_email(User.t()) :: Swoosh.Email.t()
+  def generate_email(user) do
+    new()
+    |> from(from_tuple())
+    |> to(user)
+    |> subject("You have been invited to register on FFF Trade Machine")
+    |> render_body(:registration, %{user: user, registration_url: build_registration_url()})
+  end
+
+  defp build_registration_url do
+    "#{frontend_url()}/register"
+  end
+end

--- a/lib/trade_machine/mailer/templates/email/registration.html.heex
+++ b/lib/trade_machine/mailer/templates/email/registration.html.heex
@@ -1,0 +1,25 @@
+<style>
+  .registration-link {
+    word-break: break-all;
+    color: #4f46e5;
+    text-decoration: none;
+  }
+</style>
+
+<h2 style="color: #374151; margin-bottom: 20px;">Invitation to Register</h2>
+
+<p>Hi <%= @user.display_name || @user.email %>,</p>
+
+<p>You have been invited to register on FlexFox Fantasy TradeMachine. This will allow you to submit trades with other members of the Flex Fox Fantasy Baseball League.</p>
+
+<p style="text-align: center;">
+  <a href={@registration_url} class="button">Register</a>
+</p>
+
+<p>If the button doesn't work, you can copy and paste this link into your browser:</p>
+<p><a href={@registration_url} class="registration-link"><%= @registration_url %></a></p>
+
+<p style="color: #6b7280; font-size: 14px;">Welcome to the Flex Fox Fantasy League! We look forward to having you as part of our trading community.</p>
+
+<p>Thanks,<br>
+<strong>The TradeMachine Team</strong></p>

--- a/lib/trade_machine/mailer/templates/email/registration.text.eex
+++ b/lib/trade_machine/mailer/templates/email/registration.text.eex
@@ -1,0 +1,14 @@
+Invitation to Register
+
+Hi <%= @user.display_name || @user.email %>,
+
+You have been invited to register on FlexFox Fantasy TradeMachine. This will allow you to submit trades with other members of the Flex Fox Fantasy Baseball League.
+
+Please click or copy the following link to complete the registration process:
+
+<%= @registration_url %>
+
+Welcome to the Flex Fox Fantasy League! We look forward to having you as part of our trading community.
+
+Thanks,
+The TradeMachine Team

--- a/lib/trade_machine/mailer/templates/email/test.html.heex
+++ b/lib/trade_machine/mailer/templates/email/test.html.heex
@@ -1,0 +1,10 @@
+<h2 style="color: #374151; margin-bottom: 20px;">Testing... Testing...</h2>
+
+<p>Hi <%= @user.display_name || @user.email %>,</p>
+
+<p>This is a test email from the FlexFox Fantasy TradeMachine.</p>
+
+<p style="color: #6b7280; font-size: 14px;">If you received this email, the email system is working correctly! 🎉</p>
+
+<p>Thanks,<br>
+<strong>The TradeMachine Team</strong></p>

--- a/lib/trade_machine/mailer/templates/email/test.text.eex
+++ b/lib/trade_machine/mailer/templates/email/test.text.eex
@@ -1,0 +1,10 @@
+Testing... Testing...
+
+Hi <%= @user.display_name || @user.email %>,
+
+This is a test email from the FlexFox Fantasy TradeMachine.
+
+If you received this email, the email system is working correctly!
+
+Thanks,
+The TradeMachine Team

--- a/lib/trade_machine/mailer/test_email.ex
+++ b/lib/trade_machine/mailer/test_email.ex
@@ -1,0 +1,26 @@
+defmodule TradeMachine.Mailer.TestEmail do
+  use TradeMachine.Mailer
+
+  alias TradeMachine.Data.User
+
+  @spec send(User.t()) :: {:ok, any()} | {:error, any()}
+  def send(user = %User{}) do
+    generate_email(user)
+    |> do_deliver()
+  end
+
+  @spec send!(User.t()) :: Swoosh.Email.t()
+  def send!(user = %User{}) do
+    generate_email(user)
+    |> do_deliver!()
+  end
+
+  @spec generate_email(User.t()) :: Swoosh.Email.t()
+  def generate_email(user) do
+    new()
+    |> from(from_tuple())
+    |> to(user)
+    |> subject("Test email from Flex Fox Fantasy League TradeMachine")
+    |> render_body(:test, %{user: user})
+  end
+end

--- a/test/trade_machine/mailer/registration_email_test.exs
+++ b/test/trade_machine/mailer/registration_email_test.exs
@@ -1,0 +1,171 @@
+defmodule TradeMachine.Mailer.RegistrationEmailTest do
+  use ExUnit.Case, async: true
+
+  import Swoosh.TestAssertions
+
+  alias TradeMachine.Data.User
+  alias TradeMachine.Mailer.RegistrationEmail
+  alias Swoosh.Email
+
+  describe "generate_email/1" do
+    test "creates email with proper metadata" do
+      user = build_user()
+
+      email = RegistrationEmail.generate_email(user)
+
+      assert %Email{} = email
+      assert email.subject == "You have been invited to register on FFF Trade Machine"
+      assert email.from == {"FlexFox Fantasy TradeMachine", "tradebot@flexfoxfantasy.com"}
+      assert email.to == [{"Test User", "test@example.com"}]
+    end
+
+    test "includes registration URL in email body" do
+      user = build_user()
+
+      email = RegistrationEmail.generate_email(user)
+
+      expected_url = "http://localhost:3031/register"
+
+      # Check HTML body contains registration URL
+      assert String.contains?(email.html_body, expected_url)
+
+      # Check text body contains registration URL
+      assert String.contains?(email.text_body, expected_url)
+    end
+
+    test "includes user display name in email content" do
+      user = build_user(%{display_name: "John Doe"})
+
+      email = RegistrationEmail.generate_email(user)
+
+      # Both HTML and text should contain the user's name
+      assert String.contains?(email.html_body, "Hi John Doe,")
+      assert String.contains?(email.text_body, "Hi John Doe,")
+    end
+
+    test "falls back to email when display_name is nil" do
+      user = build_user(%{display_name: nil, email: "fallback@example.com"})
+
+      email = RegistrationEmail.generate_email(user)
+
+      # Should use email as fallback
+      assert String.contains?(email.html_body, "Hi fallback@example.com,")
+      assert String.contains?(email.text_body, "Hi fallback@example.com,")
+    end
+
+    test "includes invitation message in email" do
+      user = build_user()
+
+      email = RegistrationEmail.generate_email(user)
+
+      # Check for invitation messaging
+      assert String.contains?(email.html_body, "invited to register")
+      assert String.contains?(email.text_body, "invited to register")
+      assert String.contains?(email.html_body, "Flex Fox Fantasy Baseball League")
+      assert String.contains?(email.text_body, "Flex Fox Fantasy Baseball League")
+    end
+
+    test "includes clickable register button in HTML email" do
+      user = build_user()
+
+      email = RegistrationEmail.generate_email(user)
+
+      # Check for button element in HTML
+      assert String.contains?(email.html_body, ~s{class="button"})
+      assert String.contains?(email.html_body, "Register")
+
+      # Check for fallback link
+      assert String.contains?(email.html_body, ~s{class="registration-link"})
+    end
+
+    test "includes welcome message and proper branding" do
+      user = build_user()
+
+      email = RegistrationEmail.generate_email(user)
+
+      # Check for welcome message
+      assert String.contains?(email.html_body, "Welcome to the Flex Fox Fantasy League")
+      assert String.contains?(email.text_body, "Welcome to the Flex Fox Fantasy League")
+
+      # Check for FlexFox Fantasy TradeMachine branding
+      assert String.contains?(email.html_body, "FlexFox Fantasy TradeMachine")
+      assert String.contains?(email.text_body, "FlexFox Fantasy TradeMachine")
+
+      # Check for team signature
+      assert String.contains?(email.html_body, "The TradeMachine Team")
+      assert String.contains?(email.text_body, "The TradeMachine Team")
+    end
+  end
+
+  describe "send/1" do
+    test "successfully sends registration email" do
+      user = build_user()
+
+      assert {:ok, _email} = RegistrationEmail.send(user)
+
+      # Assert email was sent using Swoosh TestAssertions
+      assert_email_sent(
+        subject: "You have been invited to register on FFF Trade Machine",
+        to: [{"Test User", "test@example.com"}],
+        from: {"FlexFox Fantasy TradeMachine", "tradebot@flexfoxfantasy.com"}
+      )
+    end
+  end
+
+  describe "send!/1" do
+    test "successfully sends registration email" do
+      user = build_user()
+
+      # send!/1 calls do_deliver!/1 which may return different values
+      # depending on the adapter implementation
+      result = RegistrationEmail.send!(user)
+
+      # The main thing is that the email gets sent
+      assert_email_sent(
+        subject: "You have been invited to register on FFF Trade Machine",
+        to: [{"Test User", "test@example.com"}],
+        from: {"FlexFox Fantasy TradeMachine", "tradebot@flexfoxfantasy.com"}
+      )
+
+      # For test adapter, result might be empty map or other value
+      # The important part is that the email was delivered
+      assert result != nil
+    end
+  end
+
+  describe "build_registration_url/1" do
+    test "generates correct registration URL" do
+      user = build_user()
+
+      # Access private function via generate_email since build_registration_url is private
+      email = RegistrationEmail.generate_email(user)
+
+      expected_url = "http://localhost:3031/register"
+      assert String.contains?(email.html_body, expected_url)
+      assert String.contains?(email.text_body, expected_url)
+    end
+
+    test "uses frontend_url from config" do
+      user = build_user()
+
+      # The URL should use the configured frontend URL
+      email = RegistrationEmail.generate_email(user)
+
+      assert String.contains?(email.html_body, "http://localhost:3031/register")
+      assert String.contains?(email.text_body, "http://localhost:3031/register")
+    end
+  end
+
+  # Helper function to build test users
+  defp build_user(attrs \\ %{}) do
+    default_attrs = %{
+      id: Ecto.UUID.generate(),
+      display_name: "Test User",
+      email: "test@example.com",
+      status: :active,
+      role: :admin
+    }
+
+    struct(User, Map.merge(default_attrs, attrs))
+  end
+end

--- a/test/trade_machine/mailer/test_email_test.exs
+++ b/test/trade_machine/mailer/test_email_test.exs
@@ -1,0 +1,138 @@
+defmodule TradeMachine.Mailer.TestEmailTest do
+  use ExUnit.Case, async: true
+
+  import Swoosh.TestAssertions
+
+  alias TradeMachine.Data.User
+  alias TradeMachine.Mailer.TestEmail
+  alias Swoosh.Email
+
+  describe "generate_email/1" do
+    test "creates email with proper metadata" do
+      user = build_user()
+
+      email = TestEmail.generate_email(user)
+
+      assert %Email{} = email
+      assert email.subject == "Test email from Flex Fox Fantasy League TradeMachine"
+      assert email.from == {"FlexFox Fantasy TradeMachine", "tradebot@flexfoxfantasy.com"}
+      assert email.to == [{"Test User", "test@example.com"}]
+    end
+
+    test "includes user display name in email content" do
+      user = build_user(%{display_name: "John Doe"})
+
+      email = TestEmail.generate_email(user)
+
+      # Both HTML and text should contain the user's name
+      assert String.contains?(email.html_body, "Hi John Doe,")
+      assert String.contains?(email.text_body, "Hi John Doe,")
+    end
+
+    test "falls back to email when display_name is nil" do
+      user = build_user(%{display_name: nil, email: "fallback@example.com"})
+
+      email = TestEmail.generate_email(user)
+
+      # Should use email as fallback
+      assert String.contains?(email.html_body, "Hi fallback@example.com,")
+      assert String.contains?(email.text_body, "Hi fallback@example.com,")
+    end
+
+    test "includes test message content" do
+      user = build_user()
+
+      email = TestEmail.generate_email(user)
+
+      # Check for test messaging
+      assert String.contains?(email.html_body, "Testing... Testing...")
+      assert String.contains?(email.text_body, "Testing... Testing...")
+      assert String.contains?(email.html_body, "test email from the FlexFox Fantasy TradeMachine")
+      assert String.contains?(email.text_body, "test email from the FlexFox Fantasy TradeMachine")
+    end
+
+    test "includes success confirmation message in HTML" do
+      user = build_user()
+
+      email = TestEmail.generate_email(user)
+
+      # Check for success confirmation in HTML (with emoji)
+      assert String.contains?(email.html_body, "email system is working correctly!")
+      assert String.contains?(email.html_body, "🎉")
+    end
+
+    test "includes success confirmation message in text" do
+      user = build_user()
+
+      email = TestEmail.generate_email(user)
+
+      # Check for success confirmation in text (without emoji)
+      assert String.contains?(email.text_body, "email system is working correctly!")
+      # Text version should not have emoji
+      refute String.contains?(email.text_body, "🎉")
+    end
+
+    test "includes proper branding elements" do
+      user = build_user()
+
+      email = TestEmail.generate_email(user)
+
+      # Check for FlexFox Fantasy TradeMachine branding
+      assert String.contains?(email.html_body, "FlexFox Fantasy TradeMachine")
+      assert String.contains?(email.text_body, "FlexFox Fantasy TradeMachine")
+
+      # Check for team signature
+      assert String.contains?(email.html_body, "The TradeMachine Team")
+      assert String.contains?(email.text_body, "The TradeMachine Team")
+    end
+  end
+
+  describe "send/1" do
+    test "successfully sends test email" do
+      user = build_user()
+
+      assert {:ok, _email} = TestEmail.send(user)
+
+      # Assert email was sent using Swoosh TestAssertions
+      assert_email_sent(
+        subject: "Test email from Flex Fox Fantasy League TradeMachine",
+        to: [{"Test User", "test@example.com"}],
+        from: {"FlexFox Fantasy TradeMachine", "tradebot@flexfoxfantasy.com"}
+      )
+    end
+  end
+
+  describe "send!/1" do
+    test "successfully sends test email" do
+      user = build_user()
+
+      # send!/1 calls do_deliver!/1 which may return different values
+      # depending on the adapter implementation
+      result = TestEmail.send!(user)
+
+      # The main thing is that the email gets sent
+      assert_email_sent(
+        subject: "Test email from Flex Fox Fantasy League TradeMachine",
+        to: [{"Test User", "test@example.com"}],
+        from: {"FlexFox Fantasy TradeMachine", "tradebot@flexfoxfantasy.com"}
+      )
+
+      # For test adapter, result might be empty map or other value
+      # The important part is that the email was delivered
+      assert result != nil
+    end
+  end
+
+  # Helper function to build test users
+  defp build_user(attrs \\ %{}) do
+    default_attrs = %{
+      id: Ecto.UUID.generate(),
+      display_name: "Test User",
+      email: "test@example.com",
+      status: :active,
+      role: :admin
+    }
+
+    struct(User, Map.merge(default_attrs, attrs))
+  end
+end


### PR DESCRIPTION
This pull request adds support for sending registration and test emails in the TradeMachine application, along with related templates and improved code structure for email handling. It introduces new modules and templates for the new email types, refactors the email worker to reduce duplication, and enhances test coverage for these changes. Additionally, it makes minor updates to code quality configuration.

**Email System Enhancements:**

* Added new modules for sending registration (`registration_email.ex`) and test (`test_email.ex`) emails, including both HTML and plain text templates for each (`registration.html.heex`, `registration.text.eex`, `test.html.heex`, `test.text.eex`). [[1]](diffhunk://#diff-83d45e9b6c77f2ca5742e39540ba07168e257f1a7021a2d43e79167bef43f9a1R1-R30) [[2]](diffhunk://#diff-c975aac49472bd04b5a111fdd5f1ab219438822607c9a2494306623fb5e09db5R1-R26) [[3]](diffhunk://#diff-ec8bd5e0a776fa9f4633fba45969f8bc16613ab138fd08bb0e91230d40076514R1-R25) [[4]](diffhunk://#diff-2369725da8ef1d8fa4faa443aa085871baddc04881d040e46aff993c8819ed51R1-R14) [[5]](diffhunk://#diff-be1af93ab8805e94ded950794dde109feb23674179b6abf67a1443c0abb22b21R1-R10) [[6]](diffhunk://#diff-5926f716c2e2473c1b8139cef14da141444389f7e15bee2f761fc6714bd8f20bR1-R10)
* Updated `TradeMachine.Mailer` to provide `send_registration_email/1` and `send_test_email/1` functions, and modified password reset email logic to use a new user query for password reset tokens. [[1]](diffhunk://#diff-4ffc008ec4fd733b87e8e32b264e1c77405dbeb76b2d083c019ae18c59d0aad0L8-R8) [[2]](diffhunk://#diff-4ffc008ec4fd733b87e8e32b264e1c77405dbeb76b2d083c019ae18c59d0aad0R18-L21) [[3]](diffhunk://#diff-32f9e9b97d4532280369a6dd8ed405c0eaa54f3b4df381ef60cbd69c4230c641R9) [[4]](diffhunk://#diff-32f9e9b97d4532280369a6dd8ed405c0eaa54f3b4df381ef60cbd69c4230c641R41-R58)

**Email Worker Refactoring:**

* Refactored `EmailWorker` to use a helper function for sending emails with tracing and error handling, and added support for "registration" and "test" email types. [[1]](diffhunk://#diff-315b7594482d5a6febb10ac680369cc660089f88f519148bcc3b55f2952ca698L46-R56) [[2]](diffhunk://#diff-315b7594482d5a6febb10ac680369cc660089f88f519148bcc3b55f2952ca698R90-R127)

**Testing Improvements:**

* Expanded tests in `EmailWorkerTest` to cover registration and test emails, including jobs with trace context and enqueuing multiple jobs. [[1]](diffhunk://#diff-60c773ab8a7679e58b563a60921d068850dc5cfe0bfa89a9cf1b7fa16bd0f455R35-R70) [[2]](diffhunk://#diff-60c773ab8a7679e58b563a60921d068850dc5cfe0bfa89a9cf1b7fa16bd0f455R192-R211) [[3]](diffhunk://#diff-60c773ab8a7679e58b563a60921d068850dc5cfe0bfa89a9cf1b7fa16bd0f455R333-R364)

**Code Quality and Cleanup:**

* Simplified email view modules by removing redundant imports and relying on `PhoenixHTMLHelpers`. [[1]](diffhunk://#diff-247cc565ab2f75f355d0a89b68076aa8f6a7b5bd8c9dd1bde25b37c8c7e38704L6-L12) [[2]](diffhunk://#diff-9178ca4cdaace96fb5ef498de32f9d5951211bc3f105e14509ff08bc3d18b90fL6-L12)
* Updated `.credo.exs` to adjust enabled and disabled code checks, including enabling a warning for missed logger metadata keys. [[1]](diffhunk://#diff-c44b474280f99dde56e6b80c90554ced12592de34aaa8d42186984126d5521d9L69-L71) [[2]](diffhunk://#diff-c44b474280f99dde56e6b80c90554ced12592de34aaa8d42186984126d5521d9R83) [[3]](diffhunk://#diff-c44b474280f99dde56e6b80c90554ced12592de34aaa8d42186984126d5521d9L100-L104)