### PR TITLE
feat(discord): trade action DMs via Oban (DiscordWorker)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,5 @@ DISCORD_BOT_TOKEN=your_discord_bot_token_here
 DISCORD_CHANNEL_ID_PRODUCTION=your_production_channel_id_here
 DISCORD_CHANNEL_ID_STAGING=your_staging_channel_id_here
 DISCORD_GUILD_ID=your_discord_guild_id_here
+# Channel IDs above are for public trade announcements only.
+# Trade action DMs (request / submit / declined) use each user's discordUserId from the DB and the same bot token.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,11 @@ TradeMachineEx operates as a microservice that connects to **shared infrastructu
 - **Testing**: `TradeMachine.Discord.EmbedTester` for format experiments with sample data
 - **See**: `DISCORD_IMPLEMENTATION.md` for full documentation
 
+### Discord trade action DMs (Oban)
+- **Worker**: `TradeMachine.Jobs.DiscordWorker` also handles `trade_request_dm`, `trade_submit_dm`, and `trade_declined_dm` jobs (same `discord` queue as announcements).
+- **Content**: `action_dm.ex` builds embeds with action links; URLs are precomputed by TradeMachineServer (mirrors trade emails).
+- **Recipients**: Uses `user.discordUserId` from the database (no `DISCORD_CHANNEL_ID_*` involved). Staging QA: use test Discord IDs in the staging DB only.
+
 ### Discord slash commands (user-facing)
 - **Commands**: `/my-trades` (active trades), `/trade-history` (last 5 trades, optional status filter)
 - **Gateway**: `TradeMachine.Discord.Consumer` uses `use Nostrum.Consumer` (Nostrum **0.10.x**); started from `application.ex` only when `DISCORD_BOT_TOKEN` configures Nostrum

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,18 @@ See `test/trade_machine/espn/client_test.exs`, `test/trade_machine/espn/search_t
 - Test worker configuration (`queue`, `max_attempts`, `unique`) separately from `perform/1` business logic.
 - **Avoid row-lock deadlocks**: When a job syncs to both `Repo.Production` and `Repo.Staging`, both operations hit the same physical database (same test schema) inside sandbox transactions. If both repos try to upsert the same row, the second operation deadlocks waiting on the first's uncommitted lock. To avoid this, stub the external API to return an empty result set in happy-path tests, or scope DB-interaction tests to a single repo.
 
+### Testing External I/O (Discord / Nostrum)
+
+For boundaries where a third-party library owns the HTTP stack (e.g. Nostrum for Discord), use **behaviour + Application-config test double** instead of Bypass or runtime patching. Full rationale and decision criteria live in [`docs/adr/0001-testing-external-io-and-test-doubles.md`](docs/adr/0001-testing-external-io-and-test-doubles.md).
+
+**Quick reference:**
+
+- **Test doubles** are registered in `test/test_helper.exs` via `Application.put_env/3` and implemented in `test/support/`.
+- **`mock` / Meck are banned** — no runtime function patching.
+- **Bypass** is for boundaries where *our* code controls the HTTP base URL (i.e. `Req`-based clients). Use `Req.Test` for those instead (see section above).
+- **Mox/Hammox** may be added later per the ADR's criteria; for now, hand-rolled modules with `@behaviour` are sufficient.
+- **Database tests** should `use TradeMachine.DataCase, async: false` for Ecto Sandbox setup covering both repos.
+
 ### Email Testing
 
 - Import `Swoosh.TestAssertions` and use `assert_email_sent/1` to verify outgoing emails.

--- a/coveralls.json
+++ b/coveralls.json
@@ -35,6 +35,7 @@
     "lib/trade_machine/data/sync_job_execution.ex",
 
     "lib/trade_machine/discord/embed_tester.ex",
+    "lib/trade_machine/discord/client.ex",
     "lib/trade_machine/minor_league_reconciliation.ex"
   ]
 }

--- a/docs/adr/0001-testing-external-io-and-test-doubles.md
+++ b/docs/adr/0001-testing-external-io-and-test-doubles.md
@@ -1,0 +1,68 @@
+# ADR 0001: Testing External I/O and Test Doubles
+
+**Status:** Accepted  
+**Date:** 2026-04-11  
+**Context:** Discord trade-action DMs feature (PR #28)
+
+## Decision
+
+### Stubbing library-owned I/O (Nostrum / Discord)
+
+When production code calls a third-party library that owns the HTTP stack (e.g. `Nostrum.Api.*` for Discord), we introduce a thin **behaviour + Application-config double** rather than trying to intercept or replace the library's internal networking.
+
+**Pattern:**
+
+1. Define a behaviour in `lib/` with `@callback` for the boundary function(s).
+2. Write a default implementation that delegates to the real library (e.g. `TradeMachine.Discord.Client`).
+3. Write a test module in `test/support/` that `@impl`s the behaviour and returns canned values.
+4. Register the test module in `test/test_helper.exs` via `Application.put_env/3`.
+5. Production code resolves the implementation via `Application.get_env(:trade_machine, :key, DefaultModule)`.
+
+The compiler enforces callback arity/name on both sides when both modules declare `@impl true`.
+
+**Existing examples:** `:discord_interaction_api` and `:discord_application_command_api` in `test/test_helper.exs` with stub modules in `test/support/discord_api_stub.ex`.
+
+### Banned: `mock` (Hex) and Meck
+
+Runtime function patching (replacing a module's function at the BEAM level during a test) is **not allowed** in this repo. It is global, not process-safe, breaks `async: true`, and makes failures hard to reproduce.
+
+### When to use Bypass
+
+**Bypass** opens a real TCP port and serves HTTP responses. Use it **only** when:
+
+- **Your application code** controls the HTTP client's base URL (via config or function argument), and
+- You want to assert on the **HTTP request** your code sends (path, headers, body).
+
+This fits boundaries where we use `Req` with configurable options (ESPN client, sheet fetchers, etc.).
+
+**Do not use Bypass for Nostrum-backed paths.** Nostrum owns the HTTP connection to Discord, hardcodes the API host, and manages auth headers internally. Pointing Nostrum at a Bypass port is unsupported, fragile across library upgrades, and would mostly test Nostrum's HTTP layer rather than our embed/repo logic.
+
+### When to use Req.Test
+
+`Req.Test` (already used in `config/test.exs`) is preferred over Bypass when:
+
+- The boundary uses `Req` as its HTTP client, and
+- You want an in-process plug-based stub (no real TCP; faster, no port conflicts).
+
+Current usages: `:espn_req_options`, `:espn_search_req_options`, `:sheet_fetcher_req_options`, `:draft_picks_sheet_fetcher_req_options`.
+
+Choose Bypass over `Req.Test` only when you need to test real TCP behavior (connection timeouts, TLS, chunked responses) or the client is not `Req`.
+
+### When to add Mox (or Hammox / Mimic)
+
+The behaviour + hand-rolled test module approach is sufficient **until:**
+
+- Multiple test files need **different return values per test case** from the same boundary (Mox's `expect/3` is more ergonomic than swapping `Application.put_env` or managing Agent state per test).
+- A behaviour has **many callbacks** and hand-rolling a full implementation for each test scenario becomes verbose.
+- You want **strict call-count verification** ("called exactly once with these args") without writing Agent/ETS bookkeeping.
+
+When any of these apply, add `{:mox, "~> 1.0", only: :test}` to `mix.exs` and `Mox.defmock` in `test/support/`. Optionally layer **Hammox** on top for typespec validation of mock args/returns.
+
+**Mimic** (stubs existing modules without behaviours) is an allowed alternative if the team prefers it, but behaviours should still be defined for new boundaries — they document the contract regardless of which mock library is used.
+
+## Consequences
+
+- New external I/O boundaries follow the behaviour + `Application.get_env` pattern.
+- `test/test_helper.exs` is the single registration point for test doubles.
+- `coveralls.json` may skip thin I/O wrapper modules (e.g. `discord/client.ex`) that are intentionally not exercised in CI.
+- Mox/Hammox adoption is a future opt-in per the criteria above, not a prerequisite.

--- a/lib/trade_machine/discord/action_dm.ex
+++ b/lib/trade_machine/discord/action_dm.ex
@@ -1,0 +1,160 @@
+defmodule TradeMachine.Discord.ActionDm do
+  @moduledoc """
+  Builds embeds and sends Discord DMs for trade workflow notifications (request, submit, declined).
+
+  Mirrors trade email copy where practical; URLs are precomputed by the TypeScript server.
+  """
+
+  alias TradeMachine.Data.HydratedTrade
+  alias TradeMachine.Data.User
+  alias TradeMachine.Discord.Client
+
+  require Logger
+
+  @embed_color 0x3498DB
+
+  @spec send_trade_request_dm(String.t(), String.t(), String.t(), String.t(), Ecto.Repo.t()) ::
+          {:ok, map()} | {:error, term()}
+  def send_trade_request_dm(trade_id, recipient_user_id, accept_url, decline_url, repo) do
+    with {:ok, hydrated} <- fetch_hydrated_trade(trade_id, repo),
+         {:ok, discord_id} <- discord_id_for_user(recipient_user_id, repo) do
+      embed = build_request_embed(hydrated, accept_url, decline_url)
+      Client.send_dm_embed(discord_id, embed)
+    end
+  end
+
+  @spec send_trade_submit_dm(String.t(), String.t(), String.t(), Ecto.Repo.t()) ::
+          {:ok, map()} | {:error, term()}
+  def send_trade_submit_dm(trade_id, recipient_user_id, submit_url, repo) do
+    with {:ok, hydrated} <- fetch_hydrated_trade(trade_id, repo),
+         {:ok, discord_id} <- discord_id_for_user(recipient_user_id, repo) do
+      embed = build_submit_embed(hydrated, submit_url)
+      Client.send_dm_embed(discord_id, embed)
+    end
+  end
+
+  @spec send_trade_declined_dm(String.t(), String.t(), boolean(), String.t() | nil, Ecto.Repo.t()) ::
+          {:ok, map()} | {:error, term()}
+  def send_trade_declined_dm(trade_id, recipient_user_id, is_creator, view_url, repo) do
+    with {:ok, hydrated} <- fetch_hydrated_trade(trade_id, repo),
+         {:ok, discord_id} <- discord_id_for_user(recipient_user_id, repo) do
+      embed = build_declined_embed(hydrated, is_creator, view_url)
+      Client.send_dm_embed(discord_id, embed)
+    end
+  end
+
+  defp fetch_hydrated_trade(trade_id, repo) do
+    case HydratedTrade.get_by_trade_id(trade_id, repo) do
+      nil ->
+        Logger.error("Hydrated trade not found for Discord DM", trade_id: trade_id)
+        {:error, :trade_not_found}
+
+      h ->
+        {:ok, h}
+    end
+  end
+
+  defp discord_id_for_user(recipient_user_id, repo) do
+    case User.get_by_id(recipient_user_id, repo) do
+      nil ->
+        Logger.error("User not found for Discord DM", recipient_user_id: recipient_user_id)
+        {:error, :user_not_found}
+
+      %User{discord_user_id: raw} when is_binary(raw) ->
+        case String.trim(raw) do
+          "" ->
+            Logger.info("Skipping Discord DM: user has no discord_user_id",
+              recipient_user_id: recipient_user_id
+            )
+
+            {:error, :no_discord_user_id}
+
+          id ->
+            {:ok, id}
+        end
+
+      _ ->
+        Logger.info("Skipping Discord DM: user has no discord_user_id",
+          recipient_user_id: recipient_user_id
+        )
+
+        {:error, :no_discord_user_id}
+    end
+  end
+
+  defp build_request_embed(hydrated, accept_url, decline_url) do
+    title =
+      if length(hydrated.recipients) == 1 do
+        "#{hydrated.creator} requested a trade with you"
+      else
+        "#{hydrated.creator} requested a trade with you and others"
+      end
+
+    description = """
+    **#{title}**
+
+    [Accept](#{accept_url}) · [Decline](#{decline_url})
+    """
+
+    %{
+      title: "TradeMachine — action needed",
+      description: String.trim(description),
+      color: @embed_color
+    }
+  end
+
+  defp build_submit_embed(hydrated, submit_url) do
+    recipient_count = length(hydrated.recipients)
+
+    title =
+      if recipient_count == 1 do
+        "#{hd(hydrated.recipients)} accepted your trade proposal"
+      else
+        "Recipients accepted your trade proposal"
+      end
+
+    description = """
+    **#{title}**
+
+    Submit the trade to the league: [Submit trade](#{submit_url})
+    """
+
+    %{
+      title: "TradeMachine — submit your trade",
+      description: String.trim(description),
+      color: @embed_color
+    }
+  end
+
+  defp build_declined_embed(hydrated, is_creator, view_url) do
+    decliner = hydrated.declined_by || "Someone"
+
+    title_text =
+      if is_creator do
+        "Your trade proposal was declined by #{decliner}"
+      else
+        "A trade you were part of was declined by #{decliner}"
+      end
+
+    description =
+      case view_url do
+        url when is_binary(url) and url != "" ->
+          """
+          **#{title_text}**
+
+          [View trade](#{url})
+          """
+
+        _ ->
+          """
+          **#{title_text}**
+          """
+      end
+
+    %{
+      title: "TradeMachine — trade declined",
+      description: String.trim(description),
+      color: @embed_color
+    }
+  end
+end

--- a/lib/trade_machine/discord/action_dm.ex
+++ b/lib/trade_machine/discord/action_dm.ex
@@ -7,18 +7,24 @@ defmodule TradeMachine.Discord.ActionDm do
 
   alias TradeMachine.Data.HydratedTrade
   alias TradeMachine.Data.User
+  alias TradeMachine.Discord.ActionDmEmbed
   alias TradeMachine.Discord.Client
 
   require Logger
-
-  @embed_color 0x3498DB
 
   @spec send_trade_request_dm(String.t(), String.t(), String.t(), String.t(), Ecto.Repo.t()) ::
           {:ok, map()} | {:error, term()}
   def send_trade_request_dm(trade_id, recipient_user_id, accept_url, decline_url, repo) do
     with {:ok, hydrated} <- fetch_hydrated_trade(trade_id, repo),
          {:ok, discord_id} <- discord_id_for_user(recipient_user_id, repo) do
-      embed = build_request_embed(hydrated, accept_url, decline_url)
+      embed =
+        ActionDmEmbed.build_request_embed(
+          hydrated.creator,
+          hydrated.recipients,
+          accept_url,
+          decline_url
+        )
+
       Client.send_dm_embed(discord_id, embed)
     end
   end
@@ -28,7 +34,7 @@ defmodule TradeMachine.Discord.ActionDm do
   def send_trade_submit_dm(trade_id, recipient_user_id, submit_url, repo) do
     with {:ok, hydrated} <- fetch_hydrated_trade(trade_id, repo),
          {:ok, discord_id} <- discord_id_for_user(recipient_user_id, repo) do
-      embed = build_submit_embed(hydrated, submit_url)
+      embed = ActionDmEmbed.build_submit_embed(hydrated.recipients, submit_url)
       Client.send_dm_embed(discord_id, embed)
     end
   end
@@ -38,7 +44,7 @@ defmodule TradeMachine.Discord.ActionDm do
   def send_trade_declined_dm(trade_id, recipient_user_id, is_creator, view_url, repo) do
     with {:ok, hydrated} <- fetch_hydrated_trade(trade_id, repo),
          {:ok, discord_id} <- discord_id_for_user(recipient_user_id, repo) do
-      embed = build_declined_embed(hydrated, is_creator, view_url)
+      embed = ActionDmEmbed.build_declined_embed(hydrated.declined_by, is_creator, view_url)
       Client.send_dm_embed(discord_id, embed)
     end
   end
@@ -80,81 +86,5 @@ defmodule TradeMachine.Discord.ActionDm do
 
         {:error, :no_discord_user_id}
     end
-  end
-
-  defp build_request_embed(hydrated, accept_url, decline_url) do
-    title =
-      if length(hydrated.recipients) == 1 do
-        "#{hydrated.creator} requested a trade with you"
-      else
-        "#{hydrated.creator} requested a trade with you and others"
-      end
-
-    description = """
-    **#{title}**
-
-    [Accept](#{accept_url}) · [Decline](#{decline_url})
-    """
-
-    %{
-      title: "TradeMachine — action needed",
-      description: String.trim(description),
-      color: @embed_color
-    }
-  end
-
-  defp build_submit_embed(hydrated, submit_url) do
-    recipient_count = length(hydrated.recipients)
-
-    title =
-      if recipient_count == 1 do
-        "#{hd(hydrated.recipients)} accepted your trade proposal"
-      else
-        "Recipients accepted your trade proposal"
-      end
-
-    description = """
-    **#{title}**
-
-    Submit the trade to the league: [Submit trade](#{submit_url})
-    """
-
-    %{
-      title: "TradeMachine — submit your trade",
-      description: String.trim(description),
-      color: @embed_color
-    }
-  end
-
-  defp build_declined_embed(hydrated, is_creator, view_url) do
-    decliner = hydrated.declined_by || "Someone"
-
-    title_text =
-      if is_creator do
-        "Your trade proposal was declined by #{decliner}"
-      else
-        "A trade you were part of was declined by #{decliner}"
-      end
-
-    description =
-      case view_url do
-        url when is_binary(url) and url != "" ->
-          """
-          **#{title_text}**
-
-          [View trade](#{url})
-          """
-
-        _ ->
-          """
-          **#{title_text}**
-          """
-      end
-
-    %{
-      title: "TradeMachine — trade declined",
-      description: String.trim(description),
-      color: @embed_color
-    }
   end
 end

--- a/lib/trade_machine/discord/action_dm.ex
+++ b/lib/trade_machine/discord/action_dm.ex
@@ -8,7 +8,7 @@ defmodule TradeMachine.Discord.ActionDm do
   alias TradeMachine.Data.HydratedTrade
   alias TradeMachine.Data.User
   alias TradeMachine.Discord.ActionDmEmbed
-  alias TradeMachine.Discord.Client
+  alias TradeMachine.Discord.DmSender
 
   require Logger
 
@@ -25,7 +25,7 @@ defmodule TradeMachine.Discord.ActionDm do
           decline_url
         )
 
-      Client.send_dm_embed(discord_id, embed)
+      DmSender.impl().send_dm_embed(discord_id, embed)
     end
   end
 
@@ -35,7 +35,7 @@ defmodule TradeMachine.Discord.ActionDm do
     with {:ok, hydrated} <- fetch_hydrated_trade(trade_id, repo),
          {:ok, discord_id} <- discord_id_for_user(recipient_user_id, repo) do
       embed = ActionDmEmbed.build_submit_embed(hydrated.recipients, submit_url)
-      Client.send_dm_embed(discord_id, embed)
+      DmSender.impl().send_dm_embed(discord_id, embed)
     end
   end
 
@@ -45,7 +45,7 @@ defmodule TradeMachine.Discord.ActionDm do
     with {:ok, hydrated} <- fetch_hydrated_trade(trade_id, repo),
          {:ok, discord_id} <- discord_id_for_user(recipient_user_id, repo) do
       embed = ActionDmEmbed.build_declined_embed(hydrated.declined_by, is_creator, view_url)
-      Client.send_dm_embed(discord_id, embed)
+      DmSender.impl().send_dm_embed(discord_id, embed)
     end
   end
 

--- a/lib/trade_machine/discord/action_dm_embed.ex
+++ b/lib/trade_machine/discord/action_dm_embed.ex
@@ -1,0 +1,103 @@
+defmodule TradeMachine.Discord.ActionDmEmbed do
+  @moduledoc """
+  Pure functions that build Discord embed maps for trade action DMs.
+
+  Side-effect free and unit-tested; callers resolve `HydratedTrade` / DB data
+  before invoking these functions.
+  """
+
+  @embed_color 0x3498DB
+
+  @doc """
+  Embed for a trade request (accept / decline links).
+  """
+  @spec build_request_embed(String.t(), [String.t()], String.t(), String.t()) :: map()
+  def build_request_embed(creator, recipients, accept_url, decline_url)
+      when is_binary(creator) and is_list(recipients) and is_binary(accept_url) and
+             is_binary(decline_url) do
+    title =
+      if length(recipients) == 1 do
+        "#{creator} requested a trade with you"
+      else
+        "#{creator} requested a trade with you and others"
+      end
+
+    description = """
+    **#{title}**
+
+    [Accept](#{accept_url}) · [Decline](#{decline_url})
+    """
+
+    %{
+      title: "TradeMachine — action needed",
+      description: String.trim(description),
+      color: @embed_color
+    }
+  end
+
+  @doc """
+  Embed prompting the creator to submit after recipients accepted.
+  """
+  @spec build_submit_embed([String.t()], String.t()) :: map()
+  def build_submit_embed(recipients, submit_url)
+      when is_list(recipients) and is_binary(submit_url) do
+    recipient_count = length(recipients)
+
+    title =
+      if recipient_count == 1 do
+        "#{hd(recipients)} accepted your trade proposal"
+      else
+        "Recipients accepted your trade proposal"
+      end
+
+    description = """
+    **#{title}**
+
+    Submit the trade to the league: [Submit trade](#{submit_url})
+    """
+
+    %{
+      title: "TradeMachine — submit your trade",
+      description: String.trim(description),
+      color: @embed_color
+    }
+  end
+
+  @doc """
+  Embed for a declined trade. `declined_by` may be nil (shown as \"Someone\").
+  `view_url` may be nil or empty to omit the link line.
+  """
+  @spec build_declined_embed(String.t() | nil, boolean(), String.t() | nil) :: map()
+  def build_declined_embed(declined_by, is_creator, view_url)
+      when is_boolean(is_creator) do
+    decliner = declined_by || "Someone"
+
+    title_text =
+      if is_creator do
+        "Your trade proposal was declined by #{decliner}"
+      else
+        "A trade you were part of was declined by #{decliner}"
+      end
+
+    description =
+      case view_url do
+        url when is_binary(url) and url != "" ->
+          """
+          **#{title_text}**
+
+          [View trade](#{url})
+          """
+
+        _ ->
+          """
+          **#{title_text}**
+          """
+      end
+
+    %{
+      title: "TradeMachine — trade declined",
+      description: String.trim(description),
+      color: @embed_color
+    }
+  end
+end

--- a/lib/trade_machine/discord/client.ex
+++ b/lib/trade_machine/discord/client.ex
@@ -42,27 +42,34 @@ defmodule TradeMachine.Discord.Client do
     case Integer.parse(id) do
       {user_id, ""} ->
         Logger.info("Sending Discord DM embed to user #{user_id}")
-
-        case Nostrum.Api.User.create_dm(user_id) do
-          {:ok, channel} ->
-            case Nostrum.Api.Message.create(channel.id, content: "", embeds: [embed]) do
-              {:ok, message} ->
-                Logger.info("Discord DM sent successfully (message_id: #{message.id})")
-                {:ok, message}
-
-              {:error, reason} = err ->
-                Logger.error("Failed to send Discord DM message: #{inspect(reason)}")
-                err
-            end
-
-          {:error, reason} = err ->
-            Logger.error("Failed to create Discord DM channel: #{inspect(reason)}")
-            err
-        end
+        dm_embed_after_parse(user_id, embed)
 
       _ ->
         Logger.error("Invalid Discord user snowflake for DM: #{inspect(id)}")
         {:error, :invalid_discord_user_id}
+    end
+  end
+
+  defp dm_embed_after_parse(user_id, embed) do
+    case Nostrum.Api.User.create_dm(user_id) do
+      {:ok, channel} ->
+        dm_send_message(channel.id, embed)
+
+      {:error, reason} = err ->
+        Logger.error("Failed to create Discord DM channel: #{inspect(reason)}")
+        err
+    end
+  end
+
+  defp dm_send_message(channel_id, embed) do
+    case Nostrum.Api.Message.create(channel_id, content: "", embeds: [embed]) do
+      {:ok, message} ->
+        Logger.info("Discord DM sent successfully (message_id: #{message.id})")
+        {:ok, message}
+
+      {:error, reason} = err ->
+        Logger.error("Failed to send Discord DM message: #{inspect(reason)}")
+        err
     end
   end
 

--- a/lib/trade_machine/discord/client.ex
+++ b/lib/trade_machine/discord/client.ex
@@ -3,7 +3,7 @@ defmodule TradeMachine.Discord.Client do
   Thin wrapper around the Discord API for sending messages.
 
   Handles channel ID selection based on environment and provides
-  a consistent interface for sending embeds to Discord channels.
+  a consistent interface for sending embeds to Discord channels and DMs.
   """
 
   require Logger
@@ -27,6 +27,42 @@ defmodule TradeMachine.Discord.Client do
 
       channel_id ->
         send_embed(channel_id, embed)
+    end
+  end
+
+  @doc """
+  Opens a DM with the given Discord user (snowflake string), then sends an embed.
+
+  Returns `{:error, :invalid_discord_user_id}` if the ID is not a valid snowflake.
+  """
+  @spec send_dm_embed(String.t(), map()) :: {:ok, map()} | {:error, term()}
+  def send_dm_embed(discord_user_id, embed) when is_binary(discord_user_id) do
+    id = String.trim(discord_user_id)
+
+    case Integer.parse(id) do
+      {user_id, ""} ->
+        Logger.info("Sending Discord DM embed to user #{user_id}")
+
+        case Nostrum.Api.User.create_dm(user_id) do
+          {:ok, channel} ->
+            case Nostrum.Api.Message.create(channel.id, content: "", embeds: [embed]) do
+              {:ok, message} ->
+                Logger.info("Discord DM sent successfully (message_id: #{message.id})")
+                {:ok, message}
+
+              {:error, reason} = err ->
+                Logger.error("Failed to send Discord DM message: #{inspect(reason)}")
+                err
+            end
+
+          {:error, reason} = err ->
+            Logger.error("Failed to create Discord DM channel: #{inspect(reason)}")
+            err
+        end
+
+      _ ->
+        Logger.error("Invalid Discord user snowflake for DM: #{inspect(id)}")
+        {:error, :invalid_discord_user_id}
     end
   end
 

--- a/lib/trade_machine/discord/dm_sender.ex
+++ b/lib/trade_machine/discord/dm_sender.ex
@@ -1,0 +1,30 @@
+defmodule TradeMachine.Discord.DmSender do
+  @moduledoc """
+  Behaviour for sending Discord DM embeds.
+
+  The default implementation delegates to `TradeMachine.Discord.Client`.
+  In test, a stub is registered via `Application.put_env/3` in `test_helper.exs`.
+  """
+
+  @callback send_dm_embed(String.t(), map()) :: {:ok, map()} | {:error, term()}
+
+  @doc """
+  Returns the configured implementation module.
+  """
+  @spec impl() :: module()
+  def impl do
+    Application.get_env(
+      :trade_machine,
+      :discord_dm_sender,
+      TradeMachine.Discord.DmSender.Default
+    )
+  end
+end
+
+defmodule TradeMachine.Discord.DmSender.Default do
+  @moduledoc false
+  @behaviour TradeMachine.Discord.DmSender
+
+  @impl true
+  defdelegate send_dm_embed(discord_user_id, embed), to: TradeMachine.Discord.Client
+end

--- a/lib/trade_machine/jobs/discord_worker.ex
+++ b/lib/trade_machine/jobs/discord_worker.ex
@@ -1,22 +1,31 @@
 defmodule TradeMachine.Jobs.DiscordWorker do
   @moduledoc """
-  Oban worker that processes Discord trade announcement jobs.
+  Oban worker that processes Discord jobs: channel trade announcements and trade action DMs.
 
   Jobs are enqueued by the TypeScript server via direct insertion into the
-  `oban_jobs` table. The worker delegates to `TradeMachine.Discord.Announcer`
-  for the actual announcement logic.
+  `oban_jobs` table.
 
   ## Job Args
 
-      %{
-        "job_type" => "trade_announcement",
-        "data" => "trade-uuid",
-        "env" => "production" | "staging"
-      }
+  Announcement:
+
+      %{"job_type" => "trade_announcement", "data" => "trade-uuid", "env" => "production" | "staging"}
+
+  Direct messages (URLs mirror email jobs, snake_case keys):
+
+      %{"job_type" => "trade_request_dm", "trade_id" => ..., "recipient_user_id" => ...,
+        "accept_url" => ..., "decline_url" => ..., "env" => ...}
+
+      %{"job_type" => "trade_submit_dm", "trade_id" => ..., "recipient_user_id" => ...,
+        "submit_url" => ..., "env" => ...}
+
+      %{"job_type" => "trade_declined_dm", "trade_id" => ..., "recipient_user_id" => ...,
+        "is_creator" => true | false, "decline_url" => optional, "env" => ...}
   """
 
   use Oban.Worker, queue: :discord, max_attempts: 3
 
+  alias TradeMachine.Discord.ActionDm
   alias TradeMachine.Discord.Announcer
   alias TradeMachine.Tracing.TraceContext
 
@@ -51,9 +60,165 @@ defmodule TradeMachine.Jobs.DiscordWorker do
     )
   end
 
+  def perform(%Oban.Job{
+        id: job_id,
+        args:
+          %{
+            "job_type" => "trade_request_dm",
+            "trade_id" => trade_id,
+            "recipient_user_id" => recipient_user_id,
+            "accept_url" => accept_url,
+            "decline_url" => decline_url,
+            "env" => env
+          } = args
+      }) do
+    repo = select_repo(env)
+
+    TraceContext.with_extracted_context(
+      args,
+      "trademachine.elixir.discord_worker.execute",
+      dm_span_attrs(job_id, "trade_request_dm", trade_id, recipient_user_id),
+      fn ->
+        Logger.info("Processing Discord trade_request_dm",
+          job_id: job_id,
+          trade_id: trade_id,
+          recipient_user_id: recipient_user_id
+        )
+
+        result =
+          ActionDm.send_trade_request_dm(
+            trade_id,
+            recipient_user_id,
+            accept_url,
+            decline_url,
+            repo
+          )
+
+        finalize_dm_job(job_id, trade_id, "trade_request_dm", result)
+      end
+    )
+  end
+
+  def perform(%Oban.Job{
+        id: job_id,
+        args:
+          %{
+            "job_type" => "trade_submit_dm",
+            "trade_id" => trade_id,
+            "recipient_user_id" => recipient_user_id,
+            "submit_url" => submit_url,
+            "env" => env
+          } = args
+      }) do
+    repo = select_repo(env)
+
+    TraceContext.with_extracted_context(
+      args,
+      "trademachine.elixir.discord_worker.execute",
+      dm_span_attrs(job_id, "trade_submit_dm", trade_id, recipient_user_id),
+      fn ->
+        Logger.info("Processing Discord trade_submit_dm",
+          job_id: job_id,
+          trade_id: trade_id,
+          recipient_user_id: recipient_user_id
+        )
+
+        result = ActionDm.send_trade_submit_dm(trade_id, recipient_user_id, submit_url, repo)
+        finalize_dm_job(job_id, trade_id, "trade_submit_dm", result)
+      end
+    )
+  end
+
+  def perform(%Oban.Job{
+        id: job_id,
+        args:
+          %{
+            "job_type" => "trade_declined_dm",
+            "trade_id" => trade_id,
+            "recipient_user_id" => recipient_user_id,
+            "env" => env
+          } = args
+      }) do
+    repo = select_repo(env)
+    is_creator = Map.get(args, "is_creator", false)
+    decline_url = Map.get(args, "decline_url")
+
+    TraceContext.with_extracted_context(
+      args,
+      "trademachine.elixir.discord_worker.execute",
+      dm_span_attrs(job_id, "trade_declined_dm", trade_id, recipient_user_id),
+      fn ->
+        Logger.info("Processing Discord trade_declined_dm",
+          job_id: job_id,
+          trade_id: trade_id,
+          recipient_user_id: recipient_user_id
+        )
+
+        result =
+          ActionDm.send_trade_declined_dm(
+            trade_id,
+            recipient_user_id,
+            is_creator,
+            decline_url,
+            repo
+          )
+
+        finalize_dm_job(job_id, trade_id, "trade_declined_dm", result)
+      end
+    )
+  end
+
   def perform(%Oban.Job{id: job_id, args: args}) do
     Logger.error("Invalid Discord job args", job_id: job_id, args: inspect(args))
     {:error, :invalid_args}
+  end
+
+  defp dm_span_attrs(job_id, dm_kind, trade_id, recipient_user_id) do
+    %{
+      "oban.job_id" => job_id,
+      "oban.queue" => "discord",
+      "oban.worker" => "TradeMachine.Jobs.DiscordWorker",
+      "discord.job_type" => dm_kind,
+      "discord.trade_id" => trade_id,
+      "discord.recipient_user_id" => recipient_user_id,
+      "user.id" => recipient_user_id,
+      "service.name" => "trademachine-elixir",
+      "component" => "discord_worker"
+    }
+  end
+
+  defp finalize_dm_job(job_id, trade_id, kind, result) do
+    case result do
+      {:ok, _message} ->
+        Logger.info("Discord DM job completed", job_id: job_id, trade_id: trade_id, kind: kind)
+        :ok
+
+      {:error, reason}
+      when reason in [
+             :no_discord_user_id,
+             :invalid_discord_user_id,
+             :trade_not_found,
+             :user_not_found
+           ] ->
+        Logger.info("Discord DM skipped (non-retryable)",
+          job_id: job_id,
+          trade_id: trade_id,
+          kind: kind,
+          reason: reason
+        )
+
+        :ok
+
+      {:error, reason} = err ->
+        Logger.error("Discord DM failed",
+          job_id: job_id,
+          trade_id: trade_id,
+          kind: kind,
+          error: inspect(reason)
+        )
+
+        err
+    end
   end
 
   defp announce(job_id, trade_id, environment) do
@@ -88,4 +253,7 @@ defmodule TradeMachine.Jobs.DiscordWorker do
 
   defp select_environment("production"), do: :production
   defp select_environment(_), do: :staging
+
+  defp select_repo("production"), do: TradeMachine.Repo.Production
+  defp select_repo(_), do: TradeMachine.Repo.Staging
 end

--- a/test/support/test_discord_dm_sender.ex
+++ b/test/support/test_discord_dm_sender.ex
@@ -1,0 +1,9 @@
+defmodule TradeMachine.TestDiscordDmSender do
+  @moduledoc false
+  @behaviour TradeMachine.Discord.DmSender
+
+  @impl true
+  def send_dm_embed(_discord_user_id, _embed) do
+    {:ok, %{id: "stub-dm-message-id"}}
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -10,6 +10,12 @@ Application.put_env(
   TradeMachine.TestDiscordApplicationCommandApi
 )
 
+Application.put_env(
+  :trade_machine,
+  :discord_dm_sender,
+  TradeMachine.TestDiscordDmSender
+)
+
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(TradeMachine.Repo.Production, :manual)
 Ecto.Adapters.SQL.Sandbox.mode(TradeMachine.Repo.Staging, :manual)

--- a/test/trade_machine/discord/action_dm_embed_test.exs
+++ b/test/trade_machine/discord/action_dm_embed_test.exs
@@ -1,0 +1,101 @@
+defmodule TradeMachine.Discord.ActionDmEmbedTest do
+  use ExUnit.Case, async: true
+
+  alias TradeMachine.Discord.ActionDmEmbed
+
+  describe "build_request_embed/4" do
+    test "single recipient copy" do
+      embed =
+        ActionDmEmbed.build_request_embed(
+          "Alice",
+          ["Bob"],
+          "https://example.com/accept",
+          "https://example.com/decline"
+        )
+
+      assert embed.title == "TradeMachine — action needed"
+      assert embed.color == 0x3498DB
+      assert embed.description =~ "Alice requested a trade with you"
+      refute embed.description =~ "and others"
+      assert embed.description =~ "[Accept](https://example.com/accept)"
+      assert embed.description =~ "[Decline](https://example.com/decline)"
+    end
+
+    test "multiple recipients copy" do
+      embed =
+        ActionDmEmbed.build_request_embed(
+          "Alice",
+          ["Bob", "Carol"],
+          "https://example.com/a",
+          "https://example.com/d"
+        )
+
+      assert embed.description =~ "Alice requested a trade with you and others"
+    end
+  end
+
+  describe "build_submit_embed/2" do
+    test "single recipient uses their name" do
+      embed =
+        ActionDmEmbed.build_submit_embed(
+          ["Bob"],
+          "https://example.com/submit"
+        )
+
+      assert embed.title == "TradeMachine — submit your trade"
+      assert embed.description =~ "Bob accepted your trade proposal"
+      assert embed.description =~ "[Submit trade](https://example.com/submit)"
+    end
+
+    test "multiple recipients uses generic line" do
+      embed =
+        ActionDmEmbed.build_submit_embed(
+          ["Bob", "Carol"],
+          "https://example.com/submit"
+        )
+
+      assert embed.description =~ "Recipients accepted your trade proposal"
+      refute embed.description =~ "Bob accepted"
+    end
+  end
+
+  describe "build_declined_embed/3" do
+    test "creator sees decliner name and view link" do
+      embed =
+        ActionDmEmbed.build_declined_embed(
+          "Pat",
+          true,
+          "https://example.com/view"
+        )
+
+      assert embed.title == "TradeMachine — trade declined"
+      assert embed.description =~ "Your trade proposal was declined by Pat"
+      assert embed.description =~ "[View trade](https://example.com/view)"
+    end
+
+    test "non-creator copy" do
+      embed = ActionDmEmbed.build_declined_embed("Pat", false, nil)
+
+      assert embed.description =~ "A trade you were part of was declined by Pat"
+      refute embed.description =~ "[View trade]"
+    end
+
+    test "nil declined_by becomes Someone" do
+      embed = ActionDmEmbed.build_declined_embed(nil, true, nil)
+
+      assert embed.description =~ "declined by Someone"
+    end
+
+    test "empty view_url omits link" do
+      embed = ActionDmEmbed.build_declined_embed("Pat", true, "")
+
+      refute embed.description =~ "[View trade]"
+    end
+
+    test "non-binary view_url omits link" do
+      embed = ActionDmEmbed.build_declined_embed("Pat", false, :not_a_url)
+
+      refute embed.description =~ "[View trade]"
+    end
+  end
+end

--- a/test/trade_machine/discord/action_dm_test.exs
+++ b/test/trade_machine/discord/action_dm_test.exs
@@ -1,0 +1,195 @@
+defmodule TradeMachine.Discord.ActionDmTest do
+  use TradeMachine.DataCase, async: false
+
+  alias TradeMachine.Data.HydratedTrade
+  alias TradeMachine.Data.User
+  alias TradeMachine.Discord.ActionDm
+
+  @repo TradeMachine.Repo.Production
+
+  # ── trade_not_found (real Sandbox DB — no view row exists) ────────────────
+
+  describe "send_trade_request_dm/5 — trade_not_found" do
+    test "returns {:error, :trade_not_found} for unknown trade_id" do
+      user = insert_user!(%{discord_user_id: "123456789"})
+
+      assert {:error, :trade_not_found} =
+               ActionDm.send_trade_request_dm(
+                 Ecto.UUID.generate(),
+                 user.id,
+                 "http://accept",
+                 "http://decline",
+                 @repo
+               )
+    end
+  end
+
+  describe "send_trade_submit_dm/4 — trade_not_found" do
+    test "returns {:error, :trade_not_found} for unknown trade_id" do
+      assert {:error, :trade_not_found} =
+               ActionDm.send_trade_submit_dm(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 "http://submit",
+                 @repo
+               )
+    end
+  end
+
+  describe "send_trade_declined_dm/5 — trade_not_found" do
+    test "returns {:error, :trade_not_found} for unknown trade_id" do
+      assert {:error, :trade_not_found} =
+               ActionDm.send_trade_declined_dm(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 true,
+                 "http://view",
+                 @repo
+               )
+    end
+  end
+
+  # ── user / discord_id errors (mock repo to supply a hydrated trade) ───────
+
+  describe "send_trade_request_dm/5 — user errors" do
+    test "returns {:error, :user_not_found} for unknown recipient" do
+      assert {:error, :user_not_found} =
+               ActionDm.send_trade_request_dm(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 "http://accept",
+                 "http://decline",
+                 repo_with_trade_only()
+               )
+    end
+
+    test "returns {:error, :no_discord_user_id} when user has nil discord_user_id" do
+      assert {:error, :no_discord_user_id} =
+               ActionDm.send_trade_request_dm(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 "http://accept",
+                 "http://decline",
+                 repo_with_user(%{discord_user_id: nil})
+               )
+    end
+
+    test "returns {:error, :no_discord_user_id} when user has blank discord_user_id" do
+      assert {:error, :no_discord_user_id} =
+               ActionDm.send_trade_request_dm(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 "http://accept",
+                 "http://decline",
+                 repo_with_user(%{discord_user_id: "  "})
+               )
+    end
+  end
+
+  # ── Happy path (mock repo — bypasses hydrated_trades view) ────────────────
+
+  describe "send_trade_request_dm/5 — happy path" do
+    test "sends DM via stub when trade and user exist" do
+      assert {:ok, %{id: "stub-dm-message-id"}} =
+               ActionDm.send_trade_request_dm(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 "http://accept",
+                 "http://decline",
+                 full_mock_repo()
+               )
+    end
+  end
+
+  describe "send_trade_submit_dm/4 — happy path" do
+    test "sends DM via stub when trade and user exist" do
+      assert {:ok, %{id: "stub-dm-message-id"}} =
+               ActionDm.send_trade_submit_dm(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 "http://submit",
+                 full_mock_repo()
+               )
+    end
+  end
+
+  describe "send_trade_declined_dm/5 — happy path" do
+    test "sends DM via stub when trade and user exist" do
+      assert {:ok, %{id: "stub-dm-message-id"}} =
+               ActionDm.send_trade_declined_dm(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 false,
+                 "http://view",
+                 full_mock_repo()
+               )
+    end
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────────────
+
+  defp insert_user!(attrs) do
+    defaults = %{
+      id: Ecto.UUID.generate(),
+      display_name: "Test User",
+      email: "test-#{System.unique_integer([:positive])}@example.com",
+      status: :active,
+      role: :owner
+    }
+
+    params = Map.merge(defaults, attrs)
+    %User{} |> Ecto.Changeset.change(params) |> @repo.insert!()
+  end
+
+  defp build_hydrated_trade do
+    %HydratedTrade{
+      trade_id: Ecto.UUID.generate(),
+      status: :requested,
+      creator: "Team Alpha",
+      recipients: ["Team Beta"],
+      declined_by: "Team Beta",
+      traded_majors: [],
+      traded_minors: [],
+      traded_picks: []
+    }
+  end
+
+  defp repo_with_trade_only do
+    Process.put(:mock_hydrated_trade, build_hydrated_trade())
+    Process.put(:mock_user, nil)
+    __MODULE__.TradeOnlyRepo
+  end
+
+  defp repo_with_user(user_attrs) do
+    Process.put(:mock_hydrated_trade, build_hydrated_trade())
+
+    Process.put(
+      :mock_user,
+      struct(
+        User,
+        Map.merge(
+          %{
+            id: Ecto.UUID.generate(),
+            display_name: "Mock User",
+            email: "mock@example.com",
+            status: :active,
+            role: :owner
+          },
+          user_attrs
+        )
+      )
+    )
+
+    __MODULE__.TradeOnlyRepo
+  end
+
+  defp full_mock_repo do
+    repo_with_user(%{discord_user_id: "123456789"})
+  end
+
+  defmodule TradeOnlyRepo do
+    @moduledoc false
+    def one(_query), do: Process.get(:mock_hydrated_trade)
+    def get(_schema, _id), do: Process.get(:mock_user)
+  end
+end

--- a/test/trade_machine/discord/trades_integration_test.exs
+++ b/test/trade_machine/discord/trades_integration_test.exs
@@ -1,5 +1,5 @@
 defmodule TradeMachine.Discord.TradesIntegrationTest do
-  use ExUnit.Case, async: false
+  use TradeMachine.DataCase, async: false
 
   alias Decimal, as: D
   alias TradeMachine.Data.DraftPick
@@ -16,11 +16,6 @@ defmodule TradeMachine.Discord.TradesIntegrationTest do
   @repo TradeMachine.Repo.Production
 
   setup do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(@repo)
-    TestHelper.set_search_path_for_sandbox(@repo)
-    Ecto.Adapters.SQL.Sandbox.mode(@repo, {:shared, self()})
-    Ecto.Adapters.SQL.Sandbox.allow(@repo, self(), self())
-
     team_a = insert_team!(@repo, %{name: "Discord Team A"})
     team_b = insert_team!(@repo, %{name: "Discord Team B"})
 

--- a/test/trade_machine/jobs/discord_worker_test.exs
+++ b/test/trade_machine/jobs/discord_worker_test.exs
@@ -1,186 +1,117 @@
 defmodule TradeMachine.Jobs.DiscordWorkerTest do
-  use ExUnit.Case, async: true
-  use Oban.Testing, repo: TradeMachine.Repo.Production, prefix: "test"
+  use TradeMachine.DataCase, async: false
 
   alias TradeMachine.Jobs.DiscordWorker
 
-  setup do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(TradeMachine.Repo.Production)
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(TradeMachine.Repo.Staging)
-
-    TestHelper.set_search_path_for_sandbox(TradeMachine.Repo.Production)
-    TestHelper.set_search_path_for_sandbox(TradeMachine.Repo.Staging)
-
-    :ok
+  defp build_job(args, opts \\ []) do
+    %Oban.Job{
+      id: Keyword.get(opts, :id, 1),
+      args: args,
+      worker: "TradeMachine.Jobs.DiscordWorker",
+      queue: "discord"
+    }
   end
 
-  describe "worker configuration" do
-    test "uses the :discord queue" do
-      job_changeset =
-        DiscordWorker.new(%{
-          job_type: "trade_announcement",
-          data: Ecto.UUID.generate(),
-          env: "production"
-        })
+  # ── Invalid args ──────────────────────────────────────────────────────────
 
-      assert job_changeset.changes.queue == "discord"
+  describe "perform/1 — invalid args" do
+    test "returns {:error, :invalid_args} for unknown job_type" do
+      job = build_job(%{"job_type" => "bogus"})
+      assert {:error, :invalid_args} = DiscordWorker.perform(job)
     end
 
-    test "has max_attempts of 3" do
-      job_changeset =
-        DiscordWorker.new(%{
-          job_type: "trade_announcement",
-          data: Ecto.UUID.generate(),
-          env: "production"
-        })
-
-      assert job_changeset.changes.max_attempts == 3
+    test "returns {:error, :invalid_args} for empty args" do
+      job = build_job(%{})
+      assert {:error, :invalid_args} = DiscordWorker.perform(job)
     end
 
-    test "uses the correct worker name" do
-      job_changeset =
-        DiscordWorker.new(%{
-          job_type: "trade_announcement",
-          data: Ecto.UUID.generate(),
-          env: "production"
-        })
-
-      assert job_changeset.changes.worker == "TradeMachine.Jobs.DiscordWorker"
+    test "returns {:error, :invalid_args} for args missing required keys" do
+      job = build_job(%{"job_type" => "trade_request_dm", "trade_id" => "x"})
+      assert {:error, :invalid_args} = DiscordWorker.perform(job)
     end
   end
 
-  describe "perform/1 argument handling" do
-    test "returns error for invalid args (missing job_type)" do
-      result =
-        perform_job(DiscordWorker, %{
-          data: Ecto.UUID.generate(),
-          env: "production"
+  # ── finalize_dm_job: non-retryable errors are swallowed ───────────────────
+  #
+  # Without the hydrated_trades DB view (not created locally), ActionDm returns
+  # {:error, :trade_not_found}. finalize_dm_job classifies that as non-retryable
+  # and returns :ok so Oban does not retry the job. These tests exercise the
+  # full perform → ActionDm → finalize path for each DM job_type.
+
+  describe "perform/1 — trade_request_dm (non-retryable skip)" do
+    test "returns :ok when hydrated trade does not exist" do
+      job =
+        build_job(%{
+          "job_type" => "trade_request_dm",
+          "trade_id" => Ecto.UUID.generate(),
+          "recipient_user_id" => Ecto.UUID.generate(),
+          "accept_url" => "http://accept",
+          "decline_url" => "http://decline",
+          "env" => "production"
         })
 
-      assert {:error, :invalid_args} = result
-    end
-
-    test "returns error for invalid args (missing data)" do
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_announcement",
-          env: "production"
-        })
-
-      assert {:error, :invalid_args} = result
-    end
-
-    test "returns error for invalid args (missing env)" do
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_announcement",
-          data: Ecto.UUID.generate()
-        })
-
-      assert {:error, :invalid_args} = result
-    end
-
-    test "returns error for completely empty args" do
-      assert {:error, :invalid_args} = perform_job(DiscordWorker, %{})
-    end
-
-    test "returns error for invalid trade ID (not a valid UUID)" do
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_announcement",
-          data: "not-a-uuid",
-          env: "staging"
-        })
-
-      assert {:error, :invalid_trade_id} = result
-    end
-
-    test "returns error for non-existent trade (valid UUID but not in DB)" do
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_announcement",
-          data: Ecto.UUID.generate(),
-          env: "staging"
-        })
-
-      assert {:error, :trade_not_found} = result
+      assert :ok = DiscordWorker.perform(job)
     end
   end
 
-  describe "environment selection" do
-    test "production env maps to :production (returns trade_not_found, not env error)" do
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_announcement",
-          data: Ecto.UUID.generate(),
-          env: "production"
+  describe "perform/1 — trade_submit_dm (non-retryable skip)" do
+    test "returns :ok when hydrated trade does not exist" do
+      job =
+        build_job(%{
+          "job_type" => "trade_submit_dm",
+          "trade_id" => Ecto.UUID.generate(),
+          "recipient_user_id" => Ecto.UUID.generate(),
+          "submit_url" => "http://submit",
+          "env" => "production"
         })
 
-      assert {:error, :trade_not_found} = result
-    end
-
-    test "staging env maps to :staging (returns trade_not_found, not env error)" do
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_announcement",
-          data: Ecto.UUID.generate(),
-          env: "staging"
-        })
-
-      assert {:error, :trade_not_found} = result
-    end
-
-    test "development env falls back to :staging (returns trade_not_found, not env error)" do
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_announcement",
-          data: Ecto.UUID.generate(),
-          env: "development"
-        })
-
-      assert {:error, :trade_not_found} = result
+      assert :ok = DiscordWorker.perform(job)
     end
   end
 
-  describe "trade action DM jobs (args shape)" do
-    test "returns error for trade_request_dm missing accept_url" do
-      tid = Ecto.UUID.generate()
-
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_request_dm",
-          trade_id: tid,
-          recipient_user_id: Ecto.UUID.generate(),
-          decline_url: "https://x/d",
-          env: "staging"
+  describe "perform/1 — trade_declined_dm (non-retryable skip)" do
+    test "returns :ok when hydrated trade does not exist" do
+      job =
+        build_job(%{
+          "job_type" => "trade_declined_dm",
+          "trade_id" => Ecto.UUID.generate(),
+          "recipient_user_id" => Ecto.UUID.generate(),
+          "is_creator" => false,
+          "decline_url" => "http://view",
+          "env" => "staging"
         })
 
-      assert {:error, :invalid_args} = result
+      assert :ok = DiscordWorker.perform(job)
     end
 
-    test "returns error for trade_submit_dm missing submit_url" do
-      result =
-        perform_job(DiscordWorker, %{
-          job_type: "trade_submit_dm",
-          trade_id: Ecto.UUID.generate(),
-          recipient_user_id: Ecto.UUID.generate(),
-          env: "staging"
+    test "handles missing optional fields (is_creator, decline_url)" do
+      job =
+        build_job(%{
+          "job_type" => "trade_declined_dm",
+          "trade_id" => Ecto.UUID.generate(),
+          "recipient_user_id" => Ecto.UUID.generate(),
+          "env" => "staging"
         })
 
-      assert {:error, :invalid_args} = result
+      assert :ok = DiscordWorker.perform(job)
     end
+  end
 
-    test "trade_declined_dm with unknown trade/user completes without retry (skipped)" do
-      tid = Ecto.UUID.generate()
-      uid = Ecto.UUID.generate()
+  # ── env routing ───────────────────────────────────────────────────────────
 
-      assert :ok =
-               perform_job(DiscordWorker, %{
-                 job_type: "trade_declined_dm",
-                 trade_id: tid,
-                 recipient_user_id: uid,
-                 env: "staging"
-               })
+  describe "perform/1 — environment routing" do
+    test "staging env routes to staging repo" do
+      job =
+        build_job(%{
+          "job_type" => "trade_request_dm",
+          "trade_id" => Ecto.UUID.generate(),
+          "recipient_user_id" => Ecto.UUID.generate(),
+          "accept_url" => "http://a",
+          "decline_url" => "http://d",
+          "env" => "staging"
+        })
+
+      assert :ok = DiscordWorker.perform(job)
     end
   end
 end

--- a/test/trade_machine/jobs/discord_worker_test.exs
+++ b/test/trade_machine/jobs/discord_worker_test.exs
@@ -141,4 +141,46 @@ defmodule TradeMachine.Jobs.DiscordWorkerTest do
       assert {:error, :trade_not_found} = result
     end
   end
+
+  describe "trade action DM jobs (args shape)" do
+    test "returns error for trade_request_dm missing accept_url" do
+      tid = Ecto.UUID.generate()
+
+      result =
+        perform_job(DiscordWorker, %{
+          job_type: "trade_request_dm",
+          trade_id: tid,
+          recipient_user_id: Ecto.UUID.generate(),
+          decline_url: "https://x/d",
+          env: "staging"
+        })
+
+      assert {:error, :invalid_args} = result
+    end
+
+    test "returns error for trade_submit_dm missing submit_url" do
+      result =
+        perform_job(DiscordWorker, %{
+          job_type: "trade_submit_dm",
+          trade_id: Ecto.UUID.generate(),
+          recipient_user_id: Ecto.UUID.generate(),
+          env: "staging"
+        })
+
+      assert {:error, :invalid_args} = result
+    end
+
+    test "trade_declined_dm with unknown trade/user completes without retry (skipped)" do
+      tid = Ecto.UUID.generate()
+      uid = Ecto.UUID.generate()
+
+      assert :ok =
+               perform_job(DiscordWorker, %{
+                 job_type: "trade_declined_dm",
+                 trade_id: tid,
+                 recipient_user_id: uid,
+                 env: "staging"
+               })
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Implements DiscordWorker handling for trade action direct messages (request, submit prompt, decline FYI), aligned with email notification flows.

## Related
- **TradeMachineServer:** https://github.com/akosasante/TradeMachineServer/pull/185

## Deploy order
Deploy or release **TradeMachineEx before or together with** TradeMachineServer so Oban jobs enqueued by the server are understood by the worker.

## Verification
- `./test.sh` (600 tests)
- `mix format --check-formatted`
- `mix credo` (warnings only; exit 0)
